### PR TITLE
small change for when installing linux mint 22 xfce

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ Edit `/etc/gdm3/custom.conf` and set `WaylandEnable=false` in the `[daemon]` sec
 
 To be able to read the input device your local user *must* be part of the *input* group.
 You should add the *gdm* user to this group as well.
+On Linux Mint 22 Xfce Edition, replace gdm for 'lightdm'. Everything else stays the same.
 
 ```
-# usermod -a -G input gdm
+# usermod -a -G input gdm 
 # usermod -a -G input your_username
 ```
 


### PR DESCRIPTION
This tutorial also works for Linux Mint 22 xfce edition, you just need to change gdm for lightdm when defining service permissions.